### PR TITLE
Update node version + set-output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.13
+FROM alpine:3.17
 
 RUN apk --update --no-cache add nodejs npm python3 py3-pip jq curl bash git docker && \
 	ln -sf /usr/bin/python3 /usr/bin/python

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,7 +66,7 @@ function runCdkAll(){
 	cdk ${INPUT_CDK_SUBCOMMAND} ${*} --all 2>&1 | tee output.log
 	exitCode=${?}
 	set +o pipefail
-	echo ::set-output name=status_code::${exitCode}
+	echo "status_code=${exitCode}" >> $GITHUB_OUTPUT
 	output=$(cat output.log)
 
 	commentStatus="Failed"
@@ -102,7 +102,7 @@ function runCdk(){
 	cdk ${INPUT_CDK_SUBCOMMAND} ${*} "${INPUT_CDK_STACK}" 2>&1 | tee output.log
 	exitCode=${?}
 	set +o pipefail
-	echo ::set-output name=status_code::${exitCode}
+	echo "status_code=${exitCode}" >> $GITHUB_OUTPUT
 	output=$(cat output.log)
 
 	commentStatus="Failed"


### PR DESCRIPTION
Looks like some stuff in this action was out of date per warning messages I saw during runs.

1. Update to use node 18 to get rid of node 14 deprecation messages
2. Update `set-output` per https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

Tested by [updating the SHA the action references in the workflow file on a dev particle health repo branch](https://github.com/ensomata/particle-health/compare/main...dh/update-cdk-action) and noticed this got the errors to go away + it worked. [Successful build.](https://github.com/ensomata/particle-health/actions/runs/6042972887/job/16399156952)

We'll also need to update the SHA in the workflow file for the monorepo + whatever other ensomata repo uses this action to get the new stuff.